### PR TITLE
Navbar mobile fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>africa.za.atech.spring</groupId>
 	<artifactId>learnbridge</artifactId>
-	<version>2025.02</version>
+	<version>2025.04.07</version>
 
 	<properties>
 		<java.version>17</java.version>

--- a/src/main/java/africa/za/atech/spring/aio/functions/chats/ChatController.java
+++ b/src/main/java/africa/za/atech/spring/aio/functions/chats/ChatController.java
@@ -61,7 +61,7 @@ public class ChatController {
         usersService.addMandatoryAttributes(redirectAttributes, profile);
 
         usersService.requestAssistantAssignment(profile);
-        redirectAttributes.addFlashAttribute("alertList", List.of(new Alert(AlertType.WARNING, "No assistants are assigned. A request has been sent to your organisation admin. Please check back later.")));
+        redirectAttributes.addFlashAttribute("alertList", List.of(new Alert(AlertType.SUCCESS, "A request has been sent to your organisation admin. Please check back later.")));
         return "redirect:/home?requested=true";
     }
 

--- a/src/main/resources/templates/_base.html
+++ b/src/main/resources/templates/_base.html
@@ -30,24 +30,10 @@
                             <a class="dropdown-item" th:href="@{/chat(assistant=${profileObject.assistantDTOList[0].uid})}">
                                 <i class="fas fa-robot"></i> New </a>
                         </li>
-                        <li th:if="${#lists.isEmpty(profileObject.assistantDTOList)}">
-                            <a class="dropdown-item" th:href="@{/chat/request}">
+                        <li th:if="${profileObject.assistantDTOList.size() != 1}" class="dropdown-submenu">
+                            <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#newChatModal">
                                 <i class="fas fa-robot"></i> New
-
                             </a>
-                        </li>
-                        <li th:if="${not #lists.isEmpty(profileObject.assistantDTOList) and profileObject.assistantDTOList.size() > 1}" class="dropdown-submenu">
-                            <a class="dropdown-item dropdown-toggle">
-                                <i class="fas fa-users"></i> New
-                            </a>
-                            <ul class="dropdown-menu">
-                                <li th:each="assistant : ${profileObject.assistantDTOList}">
-                                    <a class="dropdown-item" th:href="@{/chat(assistant=${assistant.uid})}">
-                                        <i class="fas fa-robot"></i>
-                                        <span th:text="${assistant.name}"></span>
-                                    </a>
-                                </li>
-                            </ul>
                         </li>
                         <li>
                             <a class="dropdown-item" th:href="@{/chat/list}">
@@ -105,6 +91,32 @@
         </div>
     </div>
 </nav>
+<div class="modal fade" id="newChatModal" tabindex="-1" aria-labelledby="newChatModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="newChatModalLabel">New Chat</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div th:if="${#lists.isEmpty(profileObject.assistantDTOList)}">
+                    <p>You don’t have any assistants assigned.</p>
+                    <a class="btn btn-outline-success" th:href="@{/chat/request}">Request Assistant</a>
+                </div>
+                <div th:if="${profileObject.assistantDTOList.size() > 1}">
+                    <p>Select an assistant to start chatting with:</p>
+                    <ul class="list-group">
+                        <li class="list-group-item d-flex justify-content-between align-items-center"
+                            th:each="assistant : ${profileObject.assistantDTOList}">
+                            <span th:text="${assistant.name}"></span>
+                            <a class="btn btn-outline-success btn-sm" th:href="@{/chat(assistant=${assistant.uid})}">Chat</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 </body>
 <main id="main" class="main container d-flex flex-column">
     <div th:fragment="_alert">


### PR DESCRIPTION
Version bump. New logic implemented for ```Chat``` -> ```New``` to address mobile view issues. 

1. Single assistant - start chat
2. No assistants - display modal to request for assistant assignment
![image](https://github.com/user-attachments/assets/ada35050-1ed8-401f-87c5-cf893f123c22)


3. Multiple assistants - display modal to select which assistant to interact with
![image](https://github.com/user-attachments/assets/c3681962-7817-4961-919e-7bff66fbdeec)




